### PR TITLE
ci: push artifacts to Harbor instead of GitHub storage

### DIFF
--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -46,11 +46,11 @@ jobs:
           EXIST=()
           for p in "${PATHS[@]}"; do compgen -G "$p" >/dev/null 2>&1 && EXIST+=("$p"); done
           if [ ${#EXIST[@]} -eq 0 ]; then echo "Nothing to push"; exit 0; fi
-          tar czf /tmp/jacoco-mainnet.tgz "${EXIST[@]}"
+          tar czf jacoco-mainnet.tgz "${EXIST[@]}"
           echo "$HARBOR_PASSWORD" | oras login "$HARBOR_REGISTRY" -u "$HARBOR_USERNAME" --password-stdin
           TAG="jacoco-mainnet-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           oras push "$HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}" \
             --artifact-type application/vnd.gero.ci-artifact.v1+tar \
             --annotation "run.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            /tmp/jacoco-mainnet.tgz:application/gzip
+            jacoco-mainnet.tgz:application/gzip
           echo "Pushed $HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}"

--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -28,9 +28,29 @@ jobs:
       - name: Run Integration Tests
         run: |
           mvn test -Dtest="*Mainnet*" -Djacoco.destFile=exportJacoco/jacoco-mainnet.exec
-      - name: Upload Jacoco Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: mainnet-tests-jacoco
-          path: exportJacoco/jacoco-mainnet.exec
-        if: always()  # Upload even if tests fail
+      - name: Set up ORAS
+        if: always()
+        uses: oras-project/setup-oras@v2
+
+      - name: Push jacoco-mainnet to Harbor
+        if: always()
+        continue-on-error: true   # never fail CI on artifact upload
+        env:
+          HARBOR_REGISTRY: ${{ secrets.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          PATHS=( exportJacoco/jacoco-mainnet.exec )
+          EXIST=()
+          for p in "${PATHS[@]}"; do compgen -G "$p" >/dev/null 2>&1 && EXIST+=("$p"); done
+          if [ ${#EXIST[@]} -eq 0 ]; then echo "Nothing to push"; exit 0; fi
+          tar czf /tmp/jacoco-mainnet.tgz "${EXIST[@]}"
+          echo "$HARBOR_PASSWORD" | oras login "$HARBOR_REGISTRY" -u "$HARBOR_USERNAME" --password-stdin
+          TAG="jacoco-mainnet-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          oras push "$HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}" \
+            --artifact-type application/vnd.gero.ci-artifact.v1+tar \
+            --annotation "run.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            /tmp/jacoco-mainnet.tgz:application/gzip
+          echo "Pushed $HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}"

--- a/.github/workflows/mainnet.yml
+++ b/.github/workflows/mainnet.yml
@@ -44,7 +44,7 @@ jobs:
           set -uo pipefail
           PATHS=( exportJacoco/jacoco-mainnet.exec )
           EXIST=()
-          for p in "${PATHS[@]}"; do compgen -G "$p" >/dev/null 2>&1 && EXIST+=("$p"); done
+          for p in "${PATHS[@]}"; do for m in $p; do [ -e "$m" ] && EXIST+=("$m"); done; done
           if [ ${#EXIST[@]} -eq 0 ]; then echo "Nothing to push"; exit 0; fi
           tar czf jacoco-mainnet.tgz "${EXIST[@]}"
           echo "$HARBOR_PASSWORD" | oras login "$HARBOR_REGISTRY" -u "$HARBOR_USERNAME" --password-stdin

--- a/.github/workflows/preprod.yml
+++ b/.github/workflows/preprod.yml
@@ -28,9 +28,29 @@ jobs:
       - name: Run Integration Tests
         run: |
           mvn test -Dtest="*Preprod*" -Djacoco.destFile=exportJacoco/jacoco-preprod.exec
-      - name: Upload Jacoco Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: preprod-tests-jacoco
-          path: exportJacoco/jacoco-preprod.exec
-        if: always()  # Upload even if tests fail
+      - name: Set up ORAS
+        if: always()
+        uses: oras-project/setup-oras@v2
+
+      - name: Push jacoco-preprod to Harbor
+        if: always()
+        continue-on-error: true   # never fail CI on artifact upload
+        env:
+          HARBOR_REGISTRY: ${{ secrets.HARBOR_REGISTRY }}
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          PATHS=( exportJacoco/jacoco-preprod.exec )
+          EXIST=()
+          for p in "${PATHS[@]}"; do compgen -G "$p" >/dev/null 2>&1 && EXIST+=("$p"); done
+          if [ ${#EXIST[@]} -eq 0 ]; then echo "Nothing to push"; exit 0; fi
+          tar czf /tmp/jacoco-preprod.tgz "${EXIST[@]}"
+          echo "$HARBOR_PASSWORD" | oras login "$HARBOR_REGISTRY" -u "$HARBOR_USERNAME" --password-stdin
+          TAG="jacoco-preprod-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          oras push "$HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}" \
+            --artifact-type application/vnd.gero.ci-artifact.v1+tar \
+            --annotation "run.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            /tmp/jacoco-preprod.tgz:application/gzip
+          echo "Pushed $HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}"

--- a/.github/workflows/preprod.yml
+++ b/.github/workflows/preprod.yml
@@ -46,11 +46,11 @@ jobs:
           EXIST=()
           for p in "${PATHS[@]}"; do compgen -G "$p" >/dev/null 2>&1 && EXIST+=("$p"); done
           if [ ${#EXIST[@]} -eq 0 ]; then echo "Nothing to push"; exit 0; fi
-          tar czf /tmp/jacoco-preprod.tgz "${EXIST[@]}"
+          tar czf jacoco-preprod.tgz "${EXIST[@]}"
           echo "$HARBOR_PASSWORD" | oras login "$HARBOR_REGISTRY" -u "$HARBOR_USERNAME" --password-stdin
           TAG="jacoco-preprod-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           oras push "$HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}" \
             --artifact-type application/vnd.gero.ci-artifact.v1+tar \
             --annotation "run.url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            /tmp/jacoco-preprod.tgz:application/gzip
+            jacoco-preprod.tgz:application/gzip
           echo "Pushed $HARBOR_REGISTRY/gero/maestro-java-client-ci:${TAG}"

--- a/.github/workflows/preprod.yml
+++ b/.github/workflows/preprod.yml
@@ -44,7 +44,7 @@ jobs:
           set -uo pipefail
           PATHS=( exportJacoco/jacoco-preprod.exec )
           EXIST=()
-          for p in "${PATHS[@]}"; do compgen -G "$p" >/dev/null 2>&1 && EXIST+=("$p"); done
+          for p in "${PATHS[@]}"; do for m in $p; do [ -e "$m" ] && EXIST+=("$m"); done; done
           if [ ${#EXIST[@]} -eq 0 ]; then echo "Nothing to push"; exit 0; fi
           tar czf jacoco-preprod.tgz "${EXIST[@]}"
           echo "$HARBOR_PASSWORD" | oras login "$HARBOR_REGISTRY" -u "$HARBOR_USERNAME" --password-stdin


### PR DESCRIPTION
## Why

The shared org-wide GitHub Actions artifact storage quota keeps filling up. This moves CI artifacts off GitHub storage and onto the in-cluster Harbor OCI registry (`registry.gerowallet.io`, project `gero`, public ingress + TLS).

## What changed

Both `mainnet.yml` and `preprod.yml` previously used `actions/upload-artifact@v4` to upload a JaCoCo coverage exec (`exportJacoco/jacoco-mainnet.exec` / `jacoco-preprod.exec`) with `if: always()`. Neither has a matching `download-artifact`, so both are coverage reports → routed to Harbor.

Each upload step is replaced with:
- `Set up ORAS` (`oras-project/setup-oras@v2`)
- A `Push ... to Harbor` step that tars the exec and runs `oras push` to `registry.gerowallet.io/gero/maestro-java-client-ci:<tag>`.

Preserved `if: always()`; push uses `continue-on-error: true` so artifact upload never fails CI. Credentials come from existing repo secrets (`HARBOR_REGISTRY`, `HARBOR_USERNAME`, `HARBOR_PASSWORD`) via `${{ secrets.* }}` — nothing hardcoded. Run commands only reference trusted env vars / `${GITHUB_*}` (no `github.event.*` interpolation).

## Harbor repo:tag

- `registry.gerowallet.io/gero/maestro-java-client-ci:jacoco-mainnet-<run_id>-<run_attempt>`
- `registry.gerowallet.io/gero/maestro-java-client-ci:jacoco-preprod-<run_id>-<run_attempt>`

Do not merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)